### PR TITLE
Replace deprecated model with dynamic config fetching

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -1,7 +1,7 @@
 {
   "Banner": {
-    "title": "Setup before Mar 17, 2026?",
-    "description": "Anthropic changed their OAuth policy. Re-run the setup to fix your scheduler."
+    "title": "Deployed before May 15, 2026?",
+    "description": "Re-run the setup once — your worker will automatically adapt to future model deprecations and header changes."
   },
   "Metadata": {
     "title": "TokFresh - Claude Token Reset Automation",

--- a/messages/ko.json
+++ b/messages/ko.json
@@ -1,7 +1,7 @@
 {
   "Banner": {
-    "title": "2026년 3월 17일 이전에 설정하셨나요?",
-    "description": "Anthropic의 OAuth 정책이 변경되었습니다. 셋업을 다시 실행하면 정상적으로 동작합니다."
+    "title": "2026년 5월 15일 이전에 배포하셨나요?",
+    "description": "셋업을 한 번만 다시 실행해 주세요 — 이후 모델 지원 중단이나 헤더 변경에 자동으로 대응합니다."
   },
   "Metadata": {
     "title": "TokFresh - Claude 토큰 리셋 자동화",

--- a/src/app/[locale]/debug/layout.tsx
+++ b/src/app/[locale]/debug/layout.tsx
@@ -1,0 +1,13 @@
+import type { Metadata } from "next";
+
+export const metadata: Metadata = {
+  robots: { index: false, follow: false },
+};
+
+export default function DebugLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  return children;
+}

--- a/src/app/[locale]/debug/page.tsx
+++ b/src/app/[locale]/debug/page.tsx
@@ -1,0 +1,365 @@
+"use client";
+
+import { useState } from "react";
+import { Button } from "@/components/ui/button";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Separator } from "@/components/ui/separator";
+import {
+  ExternalLink,
+  Loader2,
+  CheckCircle2,
+  XCircle,
+  Play,
+  Copy,
+  Check,
+  Shield,
+  ArrowLeft,
+} from "lucide-react";
+import { Link } from "@/i18n/navigation";
+import { generateAuthUrl, exchangeCode } from "@/lib/claude-oauth";
+
+interface TriggerStep {
+  name: string;
+  status: "success" | "error";
+  statusCode?: number;
+  response?: unknown;
+  error?: string;
+  durationMs: number;
+}
+
+interface TriggerResult {
+  steps: TriggerStep[];
+  newRefreshToken: string | null;
+}
+
+function TokenDisplay({
+  label,
+  value,
+  copiedField,
+  fieldKey,
+  onCopy,
+}: {
+  label: string;
+  value: string;
+  copiedField: string | null;
+  fieldKey: string;
+  onCopy: (value: string, key: string) => void;
+}) {
+  const masked =
+    value.length > 20
+      ? `${value.slice(0, 16)}...${value.slice(-4)}`
+      : value;
+
+  return (
+    <div className="flex items-center justify-between text-xs">
+      <span className="text-muted-foreground">{label}:</span>
+      <div className="flex items-center gap-1.5">
+        <code className="font-mono">{masked}</code>
+        <button
+          onClick={() => onCopy(value, fieldKey)}
+          className="rounded p-0.5 hover:bg-muted"
+        >
+          {copiedField === fieldKey ? (
+            <Check className="h-3 w-3 text-emerald-400" />
+          ) : (
+            <Copy className="h-3 w-3 text-muted-foreground" />
+          )}
+        </button>
+      </div>
+    </div>
+  );
+}
+
+function StepResult({ step }: { step: TriggerStep }) {
+  const isSuccess = step.status === "success";
+
+  return (
+    <div
+      className={`rounded-lg border p-3 ${
+        isSuccess
+          ? "border-emerald-500/30 bg-emerald-500/5"
+          : "border-destructive/30 bg-destructive/5"
+      }`}
+    >
+      <div className="flex items-center justify-between">
+        <div className="flex items-center gap-2 text-sm font-medium">
+          {isSuccess ? (
+            <CheckCircle2 className="h-4 w-4 text-emerald-400" />
+          ) : (
+            <XCircle className="h-4 w-4 text-destructive" />
+          )}
+          {step.name}
+        </div>
+        <div className="flex items-center gap-2 text-xs text-muted-foreground">
+          {step.statusCode && (
+            <span
+              className={
+                step.statusCode >= 400 ? "text-destructive font-medium" : ""
+              }
+            >
+              HTTP {step.statusCode}
+            </span>
+          )}
+          <span>{step.durationMs}ms</span>
+        </div>
+      </div>
+      {(step.response || step.error) && (
+        <pre className="mt-2 max-h-64 overflow-auto rounded bg-black/30 p-2 text-xs leading-relaxed whitespace-pre-wrap break-all">
+          {step.error ?? JSON.stringify(step.response, null, 2)}
+        </pre>
+      )}
+    </div>
+  );
+}
+
+export default function TestPage() {
+  const [oauthOpened, setOauthOpened] = useState(false);
+  const [authCode, setAuthCode] = useState("");
+  const [isExchanging, setIsExchanging] = useState(false);
+  const [exchangeError, setExchangeError] = useState<string | null>(null);
+  const [accessToken, setAccessToken] = useState("");
+  const [refreshToken, setRefreshToken] = useState("");
+
+  const [isTriggering, setIsTriggering] = useState(false);
+  const [triggerResult, setTriggerResult] = useState<TriggerResult | null>(
+    null,
+  );
+
+  const [copiedField, setCopiedField] = useState<string | null>(null);
+
+  const copyToClipboard = async (text: string, field: string) => {
+    await navigator.clipboard.writeText(text);
+    setCopiedField(field);
+    setTimeout(() => setCopiedField(null), 2000);
+  };
+
+  const handleConnect = async () => {
+    const { url, verifier } = await generateAuthUrl();
+    sessionStorage.setItem("tokfresh_test_verifier", verifier);
+    window.open(url, "_blank", "noopener");
+    setOauthOpened(true);
+  };
+
+  const handleExchange = async () => {
+    const verifier = sessionStorage.getItem("tokfresh_test_verifier");
+    if (!verifier) {
+      setExchangeError("Session expired. Click 'Connect Claude' again.");
+      return;
+    }
+
+    setIsExchanging(true);
+    setExchangeError(null);
+
+    const result = await exchangeCode(authCode, verifier);
+
+    if (result.success) {
+      sessionStorage.removeItem("tokfresh_test_verifier");
+      setAccessToken(result.accessToken ?? "");
+      setRefreshToken(result.refreshToken ?? "");
+    } else {
+      setExchangeError(result.error ?? "Exchange failed");
+    }
+
+    setIsExchanging(false);
+  };
+
+  const handleTrigger = async (mode: "full" | "api-only") => {
+    setIsTriggering(true);
+    setTriggerResult(null);
+
+    try {
+      const payload =
+        mode === "full" ? { refreshToken } : { accessToken };
+
+      const res = await fetch("/api/debug/trigger", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(payload),
+      });
+
+      const data: TriggerResult = await res.json();
+      setTriggerResult(data);
+
+      if (data.newRefreshToken) {
+        setRefreshToken(data.newRefreshToken);
+      }
+    } catch (err) {
+      setTriggerResult({
+        steps: [
+          {
+            name: "Request",
+            status: "error",
+            error: err instanceof Error ? err.message : String(err),
+            durationMs: 0,
+          },
+        ],
+        newRefreshToken: null,
+      });
+    }
+
+    setIsTriggering(false);
+  };
+
+  const hasTokens = !!accessToken && !!refreshToken;
+
+  return (
+    <div className="mx-auto max-w-2xl space-y-6 p-6">
+      <div>
+        <Link
+          href="/"
+          className="mb-4 inline-flex items-center gap-1 text-sm text-muted-foreground hover:text-foreground"
+        >
+          <ArrowLeft className="h-3 w-3" /> Back
+        </Link>
+        <h1 className="text-2xl font-bold tracking-tight">
+          TokFresh Debug Tool
+        </h1>
+        <p className="mt-1 text-sm text-muted-foreground">
+          Test OAuth authentication and trigger without Cloudflare deployment.
+        </p>
+      </div>
+
+      <Card>
+        <CardHeader>
+          <CardTitle className="flex items-center gap-2 text-lg">
+            <Shield className="h-4 w-4" />
+            1. OAuth Authentication
+          </CardTitle>
+          <CardDescription>
+            Connect your Claude account to obtain tokens.
+          </CardDescription>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          <Button onClick={handleConnect} className="w-full">
+            <ExternalLink className="mr-2 h-4 w-4" />
+            Connect Claude
+          </Button>
+
+          {oauthOpened && !hasTokens && (
+            <div className="space-y-3 rounded-lg border p-4">
+              <p className="text-sm text-muted-foreground">
+                Authorize on the opened page, then paste the code below.
+              </p>
+              <div className="flex gap-2">
+                <Input
+                  placeholder="Paste auth code here..."
+                  value={authCode}
+                  onChange={(e) => setAuthCode(e.target.value)}
+                />
+                <Button
+                  onClick={handleExchange}
+                  disabled={!authCode.trim() || isExchanging}
+                >
+                  {isExchanging ? (
+                    <Loader2 className="h-4 w-4 animate-spin" />
+                  ) : (
+                    "Verify"
+                  )}
+                </Button>
+              </div>
+              {exchangeError && (
+                <p className="text-sm text-destructive">{exchangeError}</p>
+              )}
+            </div>
+          )}
+
+          {hasTokens && (
+            <div className="space-y-2 rounded-lg border border-emerald-500/30 bg-emerald-500/5 p-4">
+              <div className="flex items-center gap-2 text-sm font-medium text-emerald-400">
+                <CheckCircle2 className="h-4 w-4" />
+                Tokens obtained
+              </div>
+              <div className="space-y-1.5">
+                <TokenDisplay
+                  label="Access Token"
+                  value={accessToken}
+                  copiedField={copiedField}
+                  fieldKey="access"
+                  onCopy={copyToClipboard}
+                />
+                <TokenDisplay
+                  label="Refresh Token"
+                  value={refreshToken}
+                  copiedField={copiedField}
+                  fieldKey="refresh"
+                  onCopy={copyToClipboard}
+                />
+              </div>
+            </div>
+          )}
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardHeader>
+          <CardTitle className="flex items-center gap-2 text-lg">
+            <Play className="h-4 w-4" />
+            2. Test Trigger
+          </CardTitle>
+          <CardDescription>
+            Run the same refresh + API call that the Cloudflare Worker executes.
+          </CardDescription>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          <div className="space-y-2">
+            <Label>Refresh Token</Label>
+            <Input
+              placeholder="Auto-filled from step 1, or paste manually..."
+              value={refreshToken}
+              onChange={(e) => setRefreshToken(e.target.value)}
+              className="font-mono text-xs"
+            />
+          </div>
+
+          <div className="flex gap-2">
+            <Button
+              onClick={() => handleTrigger("full")}
+              disabled={!refreshToken.trim() || isTriggering}
+              className="flex-1"
+            >
+              {isTriggering ? (
+                <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+              ) : (
+                <Play className="mr-2 h-4 w-4" />
+              )}
+              Test Full Trigger
+            </Button>
+            <Button
+              variant="outline"
+              onClick={() => handleTrigger("api-only")}
+              disabled={!accessToken.trim() || isTriggering}
+            >
+              API Only
+            </Button>
+          </div>
+
+          {triggerResult && (
+            <div className="space-y-3">
+              <Separator />
+              <h4 className="text-sm font-medium">Results</h4>
+              {triggerResult.steps.map((step, i) => (
+                <StepResult key={i} step={step} />
+              ))}
+
+              {triggerResult.newRefreshToken && (
+                <div className="rounded-lg border border-amber-500/30 bg-amber-500/5 p-3">
+                  <p className="text-xs text-amber-400">
+                    Refresh token rotated — new token auto-applied above.
+                  </p>
+                </div>
+              )}
+            </div>
+          )}
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/src/app/[locale]/setup/page.tsx
+++ b/src/app/[locale]/setup/page.tsx
@@ -205,7 +205,7 @@ export default function SetupPage() {
     trackEvent({ action: "setup_cf_verify_success", params: { attempt } });
 
     const cronExpression = timeToCron(schedule, state.timezone);
-    const workerCode = generateWorkerCode(window.location.origin);
+    const workerCode = generateWorkerCode();
 
     let notificationConfig: string | undefined;
     if (state.notificationType !== "none" && state.notificationWebhook) {

--- a/src/app/[locale]/setup/page.tsx
+++ b/src/app/[locale]/setup/page.tsx
@@ -205,7 +205,7 @@ export default function SetupPage() {
     trackEvent({ action: "setup_cf_verify_success", params: { attempt } });
 
     const cronExpression = timeToCron(schedule, state.timezone);
-    const workerCode = generateWorkerCode();
+    const workerCode = generateWorkerCode(window.location.origin);
 
     let notificationConfig: string | undefined;
     if (state.notificationType !== "none" && state.notificationWebhook) {

--- a/src/app/api/config/headers/route.ts
+++ b/src/app/api/config/headers/route.ts
@@ -1,0 +1,21 @@
+import { NextResponse } from "next/server";
+
+const CLI_VERSION = "2.1.80";
+const MODEL = "claude-haiku-4-5-20251001";
+
+const HEADERS_CONFIG = {
+  "anthropic-version": "2023-06-01",
+  "anthropic-beta":
+    "claude-code-20250219,oauth-2025-04-20,interleaved-thinking-2025-05-14,prompt-caching-scope-2026-01-05",
+  "user-agent": `claude-cli/${CLI_VERSION} (external, cli)`,
+  "x-app": "cli",
+  "x-anthropic-billing-header": `cc_version=${CLI_VERSION}.${MODEL}; cc_entrypoint=cli; cch=00000;`,
+};
+
+export async function GET() {
+  return NextResponse.json(HEADERS_CONFIG, {
+    headers: {
+      "cache-control": "public, max-age=300, s-maxage=300",
+    },
+  });
+}

--- a/src/app/api/config/headers/route.ts
+++ b/src/app/api/config/headers/route.ts
@@ -1,19 +1,8 @@
 import { NextResponse } from "next/server";
-
-const CLI_VERSION = "2.1.80";
-const MODEL = "claude-haiku-4-5-20251001";
-
-const HEADERS_CONFIG = {
-  "anthropic-version": "2023-06-01",
-  "anthropic-beta":
-    "claude-code-20250219,oauth-2025-04-20,interleaved-thinking-2025-05-14,prompt-caching-scope-2026-01-05",
-  "user-agent": `claude-cli/${CLI_VERSION} (external, cli)`,
-  "x-app": "cli",
-  "x-anthropic-billing-header": `cc_version=${CLI_VERSION}.${MODEL}; cc_entrypoint=cli; cch=00000;`,
-};
+import { CLAUDE_HEADERS } from "@/lib/claude-config";
 
 export async function GET() {
-  return NextResponse.json(HEADERS_CONFIG, {
+  return NextResponse.json(CLAUDE_HEADERS, {
     headers: {
       "cache-control": "public, max-age=300, s-maxage=300",
     },

--- a/src/app/api/config/model/route.ts
+++ b/src/app/api/config/model/route.ts
@@ -1,9 +1,8 @@
 import { NextResponse } from "next/server";
-
-const MODEL = "claude-haiku-4-5-20251001";
+import { CLAUDE_MODEL } from "@/lib/claude-config";
 
 export async function GET() {
-  return new NextResponse(MODEL, {
+  return new NextResponse(CLAUDE_MODEL, {
     headers: {
       "content-type": "text/plain",
       "cache-control": "public, max-age=300, s-maxage=300",

--- a/src/app/api/config/model/route.ts
+++ b/src/app/api/config/model/route.ts
@@ -1,0 +1,12 @@
+import { NextResponse } from "next/server";
+
+const MODEL = "claude-haiku-4-5-20251001";
+
+export async function GET() {
+  return new NextResponse(MODEL, {
+    headers: {
+      "content-type": "text/plain",
+      "cache-control": "public, max-age=300, s-maxage=300",
+    },
+  });
+}

--- a/src/app/api/debug/trigger/route.ts
+++ b/src/app/api/debug/trigger/route.ts
@@ -1,0 +1,149 @@
+import { NextRequest, NextResponse } from "next/server";
+import { CLAUDE_MODEL, CLAUDE_HEADERS } from "@/lib/claude-config";
+
+const CLIENT_ID = "9d1c250a-e61b-44d9-88ed-5944d1962f5e";
+const TOKEN_ENDPOINT = "https://console.anthropic.com/v1/oauth/token";
+const MESSAGES_ENDPOINT = "https://api.anthropic.com/v1/messages";
+
+interface TriggerStep {
+  name: string;
+  status: "success" | "error";
+  statusCode?: number;
+  response?: unknown;
+  error?: string;
+  durationMs: number;
+}
+
+export async function POST(request: NextRequest) {
+  let body: { refreshToken?: string; accessToken?: string };
+
+  try {
+    body = await request.json();
+  } catch {
+    return NextResponse.json(
+      { error: "Invalid JSON body" },
+      { status: 400 },
+    );
+  }
+
+  const { refreshToken, accessToken: providedAccessToken } = body;
+
+  if (!refreshToken && !providedAccessToken) {
+    return NextResponse.json(
+      { error: "Provide refreshToken or accessToken" },
+      { status: 400 },
+    );
+  }
+
+  const steps: TriggerStep[] = [];
+  let accessToken = providedAccessToken ?? null;
+  let newRefreshToken: string | null = null;
+
+  if (refreshToken && !providedAccessToken) {
+    const start = Date.now();
+    try {
+      const res = await fetch(TOKEN_ENDPOINT, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          grant_type: "refresh_token",
+          refresh_token: refreshToken,
+          client_id: CLIENT_ID,
+        }),
+      });
+
+      const text = await res.text();
+      const durationMs = Date.now() - start;
+
+      if (!res.ok) {
+        let parsed: unknown;
+        try {
+          parsed = JSON.parse(text);
+        } catch {
+          parsed = text;
+        }
+        steps.push({
+          name: "Token Refresh",
+          status: "error",
+          statusCode: res.status,
+          response: parsed,
+          durationMs,
+        });
+        return NextResponse.json({ steps, newRefreshToken: null });
+      }
+
+      const data = JSON.parse(text);
+      accessToken = data.access_token;
+      newRefreshToken = data.refresh_token ?? null;
+
+      steps.push({
+        name: "Token Refresh",
+        status: "success",
+        statusCode: res.status,
+        response: {
+          hasAccessToken: !!accessToken,
+          hasNewRefreshToken: !!newRefreshToken,
+        },
+        durationMs,
+      });
+    } catch (err) {
+      steps.push({
+        name: "Token Refresh",
+        status: "error",
+        error: err instanceof Error ? err.message : String(err),
+        durationMs: Date.now() - start,
+      });
+      return NextResponse.json({ steps, newRefreshToken: null });
+    }
+  }
+
+  const apiStart = Date.now();
+  try {
+    const res = await fetch(MESSAGES_ENDPOINT, {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${accessToken}`,
+        ...CLAUDE_HEADERS,
+        "content-type": "application/json",
+      },
+      body: JSON.stringify({
+        model: CLAUDE_MODEL,
+        max_tokens: 128,
+        system: [
+          {
+            type: "text",
+            text: "You are Claude Code, Anthropic\u0027s official CLI for Claude.",
+          },
+        ],
+        messages: [{ role: "user", content: "ping" }],
+      }),
+    });
+
+    const text = await res.text();
+    const durationMs = Date.now() - apiStart;
+
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(text);
+    } catch {
+      parsed = text;
+    }
+
+    steps.push({
+      name: "Claude API Call",
+      status: res.ok ? "success" : "error",
+      statusCode: res.status,
+      response: parsed,
+      durationMs,
+    });
+  } catch (err) {
+    steps.push({
+      name: "Claude API Call",
+      status: "error",
+      error: err instanceof Error ? err.message : String(err),
+      durationMs: Date.now() - apiStart,
+    });
+  }
+
+  return NextResponse.json({ steps, newRefreshToken });
+}

--- a/src/app/api/ping/route.ts
+++ b/src/app/api/ping/route.ts
@@ -1,0 +1,5 @@
+import { NextResponse } from "next/server";
+
+export async function POST() {
+  return new NextResponse(null, { status: 204 });
+}

--- a/src/components/announcement-banner.tsx
+++ b/src/components/announcement-banner.tsx
@@ -4,7 +4,7 @@ import { useState, useEffect } from "react";
 import { useTranslations } from "next-intl";
 import { X, AlertTriangle } from "lucide-react";
 
-const DISMISS_KEY = "tokfresh_banner_mar17_dismissed";
+const DISMISS_KEY = "tokfresh_banner_may15_dismissed";
 
 export function AnnouncementBanner() {
   const t = useTranslations("Banner");
@@ -25,7 +25,7 @@ export function AnnouncementBanner() {
 
   return (
     <div className="relative border-b border-amber-500/30 bg-amber-500/10 px-4 py-2.5 text-center text-sm text-amber-300">
-      <div className="mx-auto flex max-w-4xl items-center justify-center gap-2">
+      <div className="mx-auto flex max-w-6xl items-center justify-center gap-2">
         <AlertTriangle className="hidden h-4 w-4 shrink-0 sm:block" />
         <p>
           <span className="font-medium">{t("title")}</span>

--- a/src/lib/claude-config.ts
+++ b/src/lib/claude-config.ts
@@ -1,0 +1,12 @@
+const CLI_VERSION = "2.1.80";
+
+export const CLAUDE_MODEL = "claude-haiku-4-5-20251001";
+
+export const CLAUDE_HEADERS: Record<string, string> = {
+  "anthropic-version": "2023-06-01",
+  "anthropic-beta":
+    "claude-code-20250219,oauth-2025-04-20,interleaved-thinking-2025-05-14,prompt-caching-scope-2026-01-05",
+  "user-agent": `claude-cli/${CLI_VERSION} (external, cli)`,
+  "x-app": "cli",
+  "x-anthropic-billing-header": `cc_version=${CLI_VERSION}.${CLAUDE_MODEL}; cc_entrypoint=cli; cch=00000;`,
+};

--- a/src/lib/worker-template.ts
+++ b/src/lib/worker-template.ts
@@ -9,12 +9,12 @@ const FALLBACK_HEADERS = {
   "x-anthropic-billing-header": `cc_version=2.1.80.${DEFAULT_MODEL}; cc_entrypoint=cli; cch=00000;`,
 };
 
-export function generateWorkerCode(baseUrl: string): string {
+export function generateWorkerCode(): string {
   const fallbackHeadersJson = JSON.stringify(FALLBACK_HEADERS);
 
   return `export default {
   async scheduled(event, env, ctx) {
-    const TOKFRESH_BASE = '${baseUrl}';
+    const TOKFRESH_BASE = 'https://tokfresh.com';
     const FALLBACK_MODEL = '${DEFAULT_MODEL}';
     const FALLBACK_HEADERS = ${fallbackHeadersJson};
 

--- a/src/lib/worker-template.ts
+++ b/src/lib/worker-template.ts
@@ -138,6 +138,8 @@ export function generateWorkerCode(baseUrl: string): string {
         await notify('TokFresh: Successfully refreshed at ' + now);
       }
 
+      try { await fetch(TOKFRESH_BASE + '/api/ping', { method: 'POST' }); } catch {}
+
       console.log('Token timer refreshed successfully');
     } catch (error) {
       console.error('Worker error:', error.message);
@@ -146,6 +148,8 @@ export function generateWorkerCode(baseUrl: string): string {
         const now = new Date().toLocaleString('en-US', { timeZone: env.TIMEZONE || 'UTC' });
         await notify('TokFresh: Failed at ' + now + ': ' + error.message);
       }
+
+      try { await fetch(TOKFRESH_BASE + '/api/ping', { method: 'POST' }); } catch {}
 
       throw error;
     }

--- a/src/lib/worker-template.ts
+++ b/src/lib/worker-template.ts
@@ -1,6 +1,22 @@
-export function generateWorkerCode(): string {
+const DEFAULT_MODEL = "claude-haiku-4-5-20251001";
+
+export function generateWorkerCode(baseUrl: string): string {
   return `export default {
   async scheduled(event, env, ctx) {
+    const TOKFRESH_BASE = '${baseUrl}';
+    const FALLBACK_MODEL = '${DEFAULT_MODEL}';
+
+    async function fetchModel() {
+      try {
+        const res = await fetch(TOKFRESH_BASE + '/api/config/model');
+        if (!res.ok) return FALLBACK_MODEL;
+        const text = (await res.text()).trim();
+        return text || FALLBACK_MODEL;
+      } catch {
+        return FALLBACK_MODEL;
+      }
+    }
+
     async function notify(message) {
       if (!env.NOTIFICATION_CONFIG) return;
       const config = JSON.parse(env.NOTIFICATION_CONFIG);
@@ -30,6 +46,8 @@ export function generateWorkerCode(): string {
     }
 
     try {
+      const model = await fetchModel();
+
       // Read refresh token from KV (fallback to env secret for initial run)
       let refreshToken = await env.TOKEN_STORE.get('refresh_token');
       if (!refreshToken) {
@@ -75,11 +93,11 @@ export function generateWorkerCode(): string {
           'anthropic-beta': 'claude-code-20250219,oauth-2025-04-20,interleaved-thinking-2025-05-14,prompt-caching-scope-2026-01-05',
           'user-agent': 'claude-cli/2.1.80 (external, cli)',
           'x-app': 'cli',
-          'x-anthropic-billing-header': 'cc_version=2.1.80.claude-sonnet-4-20250514; cc_entrypoint=cli; cch=00000;',
+          'x-anthropic-billing-header': 'cc_version=2.1.80.' + model + '; cc_entrypoint=cli; cch=00000;',
           'content-type': 'application/json'
         },
         body: JSON.stringify({
-          model: 'claude-sonnet-4-20250514',
+          model: model,
           max_tokens: 128,
           system: [{ type: 'text', text: 'You are Claude Code, Anthropic\\u0027s official CLI for Claude.' }],
           messages: [{ role: 'user', content: 'ping' }]

--- a/src/lib/worker-template.ts
+++ b/src/lib/worker-template.ts
@@ -1,10 +1,22 @@
 const DEFAULT_MODEL = "claude-haiku-4-5-20251001";
 
+const FALLBACK_HEADERS = {
+  "anthropic-version": "2023-06-01",
+  "anthropic-beta":
+    "claude-code-20250219,oauth-2025-04-20,interleaved-thinking-2025-05-14,prompt-caching-scope-2026-01-05",
+  "user-agent": "claude-cli/2.1.80 (external, cli)",
+  "x-app": "cli",
+  "x-anthropic-billing-header": `cc_version=2.1.80.${DEFAULT_MODEL}; cc_entrypoint=cli; cch=00000;`,
+};
+
 export function generateWorkerCode(baseUrl: string): string {
+  const fallbackHeadersJson = JSON.stringify(FALLBACK_HEADERS);
+
   return `export default {
   async scheduled(event, env, ctx) {
     const TOKFRESH_BASE = '${baseUrl}';
     const FALLBACK_MODEL = '${DEFAULT_MODEL}';
+    const FALLBACK_HEADERS = ${fallbackHeadersJson};
 
     async function fetchModel() {
       try {
@@ -14,6 +26,17 @@ export function generateWorkerCode(baseUrl: string): string {
         return text || FALLBACK_MODEL;
       } catch {
         return FALLBACK_MODEL;
+      }
+    }
+
+    async function fetchHeaders() {
+      try {
+        const res = await fetch(TOKFRESH_BASE + '/api/config/headers');
+        if (!res.ok) return FALLBACK_HEADERS;
+        const data = await res.json();
+        return Object.assign({}, FALLBACK_HEADERS, data);
+      } catch {
+        return FALLBACK_HEADERS;
       }
     }
 
@@ -47,6 +70,7 @@ export function generateWorkerCode(baseUrl: string): string {
 
     try {
       const model = await fetchModel();
+      const dynamicHeaders = await fetchHeaders();
 
       // Read refresh token from KV (fallback to env secret for initial run)
       let refreshToken = await env.TOKEN_STORE.get('refresh_token');
@@ -89,11 +113,11 @@ export function generateWorkerCode(baseUrl: string): string {
         method: 'POST',
         headers: {
           'Authorization': 'Bearer ' + accessToken,
-          'anthropic-version': '2023-06-01',
-          'anthropic-beta': 'claude-code-20250219,oauth-2025-04-20,interleaved-thinking-2025-05-14,prompt-caching-scope-2026-01-05',
-          'user-agent': 'claude-cli/2.1.80 (external, cli)',
-          'x-app': 'cli',
-          'x-anthropic-billing-header': 'cc_version=2.1.80.' + model + '; cc_entrypoint=cli; cch=00000;',
+          'anthropic-version': dynamicHeaders['anthropic-version'],
+          'anthropic-beta': dynamicHeaders['anthropic-beta'],
+          'user-agent': dynamicHeaders['user-agent'],
+          'x-app': dynamicHeaders['x-app'],
+          'x-anthropic-billing-header': dynamicHeaders['x-anthropic-billing-header'],
           'content-type': 'application/json'
         },
         body: JSON.stringify({


### PR DESCRIPTION
## Summary

- `claude-sonnet-4-20250514` has been [deprecated by Anthropic](https://platform.claude.com/docs/ko/about-claude/model-deprecations#2026-04-14-claude-sonnet-4-claude-opus-4), causing worker failures (404) on some orgs
- Replaced with `claude-haiku-4-5-20251001` and made model/headers dynamically fetched from the server at runtime
- Future model deprecations can be resolved with a server-side config change — no worker redeployment needed

## Changes

- **`src/lib/claude-config.ts`**: Single source of truth for model and header constants
- **`/api/config/model`**: Returns current model name (plain text, 5min cache)
- **`/api/config/headers`**: Returns API call headers (JSON, 5min cache)
- **`/api/ping`**: Anonymous invocation tracking for worker executions
- **`src/lib/worker-template.ts`**: Fetches model/headers from server with safe fallback on failure
- **`/debug`**: Debug page for OAuth and trigger testing